### PR TITLE
Update container max-width to fit-content

### DIFF
--- a/public/css/configure.css
+++ b/public/css/configure.css
@@ -307,7 +307,7 @@ body.modal-open {
 /* Removed heavy fixed gradient layer to avoid full-viewport repaints on scroll */
 
 .container {
-    max-width: 1400px;
+    max-width: fit-content;
     margin: 0 auto;
     padding: 2rem 20%;
     position: relative;


### PR DESCRIPTION
Changed max-width of container to fit-content for better responsiveness. 

This fix makes sure that the website does not look like this on Ultra-Wide screens: 

<img width="962" height="1319" alt="image" src="https://github.com/user-attachments/assets/fba236ea-f091-451e-a68c-50fdea75236e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated container layout width behavior from fixed 1400px maximum to flexible fit-content sizing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->