### PR TITLE
Handle ESM-only cacheable-lookup

### DIFF
--- a/src/utils/httpAgents.js
+++ b/src/utils/httpAgents.js
@@ -31,9 +31,6 @@
 const http = require('http');
 const https = require('https');
 const axios = require('axios');
-// Handle ESM (v7+) and CJS (v6) exports of cacheable-lookup
-let CacheableLookup = require('cacheable-lookup');
-CacheableLookup = (CacheableLookup && (CacheableLookup.default || CacheableLookup.CacheableLookup)) || CacheableLookup;
 const log = require('./logger');
 const { scsHttpsAgent } = require('./scsHttpAgent');
 
@@ -64,13 +61,26 @@ const httpsAgent = new https.Agent({
   rejectUnauthorized: true // Verify server certificates (security)
 });
 
-// DNS cache to reduce lookup latency and flakiness
-const dnsCache = new CacheableLookup({
-  maxTtl: 60,      // seconds to keep successful lookups
-  errorTtl: 0,     // don't cache failed lookups
-  cache: new Map() // in-memory cache
-});
-const dnsLookup = dnsCache.lookup.bind(dnsCache);
+// DNS cache to reduce lookup latency and flakiness.
+// cacheable-lookup v7 is ESM-only; this project is CommonJS. If npm resolves
+// an ESM-only version, keep startup working and let axios use Node's default DNS.
+let dnsLookup;
+try {
+  let CacheableLookup = require('cacheable-lookup');
+  CacheableLookup = (CacheableLookup && (CacheableLookup.default || CacheableLookup.CacheableLookup)) || CacheableLookup;
+  const dnsCache = new CacheableLookup({
+    maxTtl: 60,      // seconds to keep successful lookups
+    errorTtl: 0,     // don't cache failed lookups
+    cache: new Map() // in-memory cache
+  });
+  dnsLookup = dnsCache.lookup.bind(dnsCache);
+} catch (error) {
+  if (error?.code === 'ERR_REQUIRE_ESM') {
+    log.warn(() => '[HTTP Agents] cacheable-lookup is ESM-only in this install; DNS cache disabled');
+  } else {
+    log.warn(() => `[HTTP Agents] DNS cache unavailable: ${error.message}`);
+  }
+}
 
 log.debug(() => '[HTTP Agents] Connection pooling initialized: maxSockets=100, maxFreeSockets=20, keepAlive=true');
 


### PR DESCRIPTION
## Description

  Fixes startup failure when `cacheable-lookup` resolves to an ESM-only version. The addon is CommonJS-based, so requiring an ESM-only `cacheable-lookup` package throws `ERR_REQUIRE_ESM` before the server
  can start.

  This change makes DNS cache initialization optional: if `cacheable-lookup` cannot be loaded via `require()`, the server logs a warning and falls back to Node's default DNS lookup.

  ## Type of Change

  - [x] 🐛 Bug fix
  - [ ] ✨ New feature
  - [ ] 📝 Documentation update
  - [ ] 🌐 Translation / Localization
  - [ ] ♻️ Refactor
  - [ ] 🔧 Configuration change

  ## Related Issues

  <!-- Link any related issues: Fixes #123, Closes #456 -->

  ## Changes Made

  - Wrapped `cacheable-lookup` loading and DNS cache setup in a guarded `try/catch`.
  - Kept existing support for CommonJS-compatible `cacheable-lookup` exports.
  - Added a fallback path for `ERR_REQUIRE_ESM` so startup continues without DNS caching.
  - Preserved existing HTTP/HTTPS connection pooling behavior.

  ## Testing

  - [x] Tested locally
  - [ ] Verified addon installs correctly in Stremio
  - [ ] Tested relevant features (subtitles, translation, etc.)

  Local validation:

  ```bash
  STORAGE_TYPE=filesystem npm start
  curl -i http://localhost:7001/health

  Result: server started successfully and /health returned 200.

  ## Checklist

  - [x] Code follows the existing style
  - [x] Self-reviewed my changes
  - [x] No new warnings or errors in console

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app startup resilience when optional DNS cache support is unavailable.
  * The app now continues loading even if the DNS caching module can’t be initialized, instead of failing during startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->