### PR TITLE
fix(gemini): update default models to Gemini 3.5 Flash to fix 404 on new API keys 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -125,8 +125,8 @@ REDIS_KEY_PREFIX=stremio
 # ======================
 
 # Default Gemini model to use for translations (optional, fallback)
-# Examples: gemini-2.0-flash-exp, gemini-2.5-flash-latest, gemini-2.5-pro-latest
-# GEMINI_MODEL=gemini-flash-latest
+# Examples: gemini-3.5-flash, gemini-3.5-flash-lite, gemini-3.7-flash, gemini-3.1-flash-lite
+# GEMINI_MODEL=gemini-3.5-flash
 
 # Extended thinking mode for translations (default: 0 = disabled)
 # Controls how many tokens the AI uses for "thinking" before responding

--- a/public/config.js
+++ b/public/config.js
@@ -959,41 +959,33 @@ Translate to {target_language}.`;
      * Model-specific default configurations
      * Each model has its own optimal settings for thinking and temperature
      */
-    const GEMINI_31_FLASH_LITE_MODEL = 'gemini-3.1-flash-lite';
-    const GEMINI_FLASH_LATEST_MODEL = 'gemini-flash-latest';
-    const DEFAULT_GEMINI_MODEL = 'gemini-flash-lite-latest';
+    const DEFAULT_GEMINI_MODEL = 'gemini-3.5-flash';
 
     function normalizeGeminiModelName(modelName) {
         const normalized = typeof modelName === 'string' ? modelName.trim() : '';
-        if (normalized === `${GEMINI_31_FLASH_LITE_MODEL}-preview`) {
-            return GEMINI_31_FLASH_LITE_MODEL;
+        if (!normalized) {
+            return DEFAULT_GEMINI_MODEL;
         }
-        if (normalized === GEMINI_FLASH_LATEST_MODEL) {
+        if (normalized === 'gemini-3.1-flash-lite-preview') {
+            return 'gemini-3.1-flash-lite';
+        }
+        if (['gemini-1.5-flash', 'gemini-1.5-pro', 'gemini-2.0-flash', 'gemini-2.5-flash', 'gemini-2.5-flash-lite', 'gemini-flash-latest'].includes(normalized)) {
             return DEFAULT_GEMINI_MODEL;
         }
         return normalized;
     }
 
     const MODEL_SPECIFIC_DEFAULTS = {
-
-        'gemini-2.5-flash-lite': {
+        'gemini-3.5-flash': {
+            thinkingBudget: 0,
+            temperature: 0.5
+        },
+        'gemini-3.5-flash-lite': {
             thinkingBudget: 0,
             temperature: 0.7
         },
-        'gemini-2.5-flash-lite-preview-09-2025': {
+        'gemini-3.7-flash': {
             thinkingBudget: 0,
-            temperature: 0.7
-        },
-        'gemini-2.5-flash': {
-            thinkingBudget: -1,
-            temperature: 0.5
-        },
-        'gemini-3-flash-preview': {
-            thinkingBudget: -1,
-            temperature: 0.5
-        },
-        'gemini-3-flash-preview': {
-            thinkingBudget: -1,
             temperature: 0.5
         },
         'gemini-3.1-flash-lite': {
@@ -1003,14 +995,6 @@ Translate to {target_language}.`;
         'gemini-flash-lite-latest': {
             thinkingBudget: 0,
             temperature: 0.8
-        },
-        'gemini-2.5-pro': {
-            thinkingBudget: 1000,
-            temperature: 0.5
-        },
-        'gemini-3-pro-preview': {
-            thinkingBudget: 1000,
-            temperature: 0.5
         }
     };
 

--- a/public/partials/main.html
+++ b/public/partials/main.html
@@ -812,18 +812,17 @@
                                     data-i18n="config.gemini.model.helper">AI model for translations</span>
                             </label>
                             <select id="geminiModel" required>
-                                <option value="gemini-3.1-flash-lite"
-                                    data-i18n="config.gemini.model.options.flashLite31" selected>Gemini 3.1 Flash Lite
+                                <option value="gemini-3.5-flash"
+                                    data-i18n="config.gemini.model.options.flash35" selected>Gemini 3.5 Flash (Recommended)
                                 </option>
-                                <option value="gemini-3-flash-preview" data-i18n="config.gemini.model.options.flash3">
-                                    Gemini 3.0 Flash (beta)</option>
-                                <option value="gemini-3-pro-preview" data-i18n="config.gemini.model.options.pro3">Gemini
-                                    3.0 Pro (beta)</option>
-                                <option value="gemini-2.5-flash-lite" data-i18n="config.gemini.model.options.flashLite">
-                                    Gemini 2.5 Flash-Lite</option>
-                                <option value="gemini-2.5-flash" data-i18n="config.gemini.model.options.flash">Gemini
-                                    2.5 Flash</option>
-
+                                <option value="gemini-3.5-flash-lite" data-i18n="config.gemini.model.options.flashLite35">
+                                    Gemini 3.5 Flash-Lite (Fastest)</option>
+                                <option value="gemini-3.7-flash" data-i18n="config.gemini.model.options.flash37">Gemini
+                                    3.7 Flash</option>
+                                <option value="gemini-3.1-flash-lite" data-i18n="config.gemini.model.options.flashLite31">
+                                    Gemini 3.1 Flash Lite</option>
+                                <option value="gemini-flash-lite-latest" data-i18n="config.gemini.model.options.flashLiteLatest">
+                                    Gemini Flash-Lite Latest</option>
                             </select>
                             <div class="field-error" id="geminiModelError"
                                 data-i18n="config.validation.geminiModelRequired">Please select a model</div>

--- a/src/services/gemini.js
+++ b/src/services/gemini.js
@@ -72,8 +72,14 @@ class GeminiService {
   constructor(apiKey, model = '', advancedSettings = {}) {
     this.apiKey = typeof apiKey === 'string' ? apiKey.trim() : apiKey;
     this.authFailureCacheKey = getProviderAuthFailureCacheKey('gemini', this.apiKey);
-    // Fallback to default if model not provided (config.js handles env var override)
-    this.model = model || 'gemini-flash-lite-latest';
+    // Sanitize and normalize model name (resolves deprecated/invalid models to GEMINI_MODEL/.env fallback)
+    try {
+      const { normalizeGeminiModelName } = require('../utils/config');
+      this.model = normalizeGeminiModelName(model);
+    } catch (_) {
+      let sanitized = String(model || '').trim().replace(/^models\//, '');
+      this.model = sanitized || process.env.GEMINI_MODEL || 'gemini-3.5-flash';
+    }
     this.isGemmaModel = String(this.model).toLowerCase().includes('gemma');
     this.baseUrl = GEMINI_API_URL;
 

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -209,38 +209,50 @@ function getDefaultProviderParameters() {
 
 /**
  * Feature flag: Override deprecated/old model names with current default
- * Set to false in the future to allow users to select any model they want
- * Currently enabled to ensure all users get the latest stable model
+ * Defaults to true to ensure broken preview/alias model names from old sessions are repaired
  */
-const OVERRIDE_DEPRECATED_MODELS = true;
-const GEMINI_31_FLASH_LITE_MODEL = 'gemini-3.1-flash-lite';
-const GEMINI_FLASH_LATEST_MODEL = 'gemini-flash-latest';
-const DEFAULT_GEMINI_MODEL = 'gemini-flash-lite-latest';
-
-function normalizeGeminiModelName(modelName) {
-  const normalized = typeof modelName === 'string' ? modelName.trim() : '';
-  if (normalized === `${GEMINI_31_FLASH_LITE_MODEL}-preview`) {
-    return GEMINI_31_FLASH_LITE_MODEL;
-  }
-  if (normalized === GEMINI_FLASH_LATEST_MODEL) {
-    return DEFAULT_GEMINI_MODEL;
-  }
-  return normalized;
-}
+const OVERRIDE_DEPRECATED_MODELS = process.env.OVERRIDE_DEPRECATED_MODELS !== 'false';
+const DEFAULT_GEMINI_MODEL = process.env.GEMINI_MODEL ? process.env.GEMINI_MODEL.trim() : 'gemini-3.5-flash';
 
 /**
- * List of deprecated model names that should be replaced with the current default
- * This prevents old saved configs from using outdated or experimental models
+ * List of deprecated/invalid model names that should be replaced with the current default
+ * This prevents old saved configs from using outdated or broken model aliases
  */
 const DEPRECATED_MODEL_NAMES = [
+  'gemini-1.5-flash',
+  'gemini-1.5-pro',
+  'gemini-2.5-flash',
+  'gemini-2.5-flash-lite',
+  'gemini-2.0-flash',
+  'gemini-2.5-pro',
+  'gemini-3-flash-preview',
+  'gemini-3-pro-preview',
   'gemini-2.0-flash-exp',
-  'gemini-2.5-flash-lite-09-2025', // Old name before preview version
-  GEMINI_FLASH_LATEST_MODEL,
   'gemini-2.5-flash-latest',
   'gemini-pro-latest',
   'gemini-2.5-pro-latest',
-  'gemini-2.5-flash-preview-09-2025' // Renamed to gemini-2.5-flash
+  'gemini-2.5-flash-preview-09-2025',
+  'gemini-2.5-flash-lite-09-2025',
+  'gemini-2.5-flash-lite-preview-09-2025'
 ];
+
+function normalizeGeminiModelName(modelName) {
+  const envModel = process.env.GEMINI_MODEL ? process.env.GEMINI_MODEL.trim() : '';
+  let normalized = typeof modelName === 'string' ? modelName.trim() : '';
+  
+  // Strip 'models/' prefix if present
+  if (normalized.startsWith('models/')) {
+    normalized = normalized.slice(7).trim();
+  }
+
+  if (!normalized) {
+    return envModel || DEFAULT_GEMINI_MODEL;
+  }
+  if (OVERRIDE_DEPRECATED_MODELS && DEPRECATED_MODEL_NAMES.includes(normalized)) {
+    return envModel || DEFAULT_GEMINI_MODEL;
+  }
+  return normalized;
+}
 
 /**
  * Parse configuration from config string or session token
@@ -1096,41 +1108,29 @@ function encodeConfig(config) {
  * Each model has its own optimal settings for thinking and temperature
  */
 const MODEL_SPECIFIC_DEFAULTS = {
-  'gemma-3-27b-it': {
-    thinkingBudget: 0,      // Gemma models don't support thinking
-    temperature: 0.7        // Balanced temperature for Gemma
+  'gemini-3.5-flash': {
+    thinkingBudget: 0,
+    temperature: 0.5
   },
-  'gemini-2.5-flash-lite': {
-    thinkingBudget: 0,      // No thinking for lite model
-    temperature: 0.8        // Higher temperature for creativity
+  'gemini-3.5-flash-lite': {
+    thinkingBudget: 0,
+    temperature: 0.7
   },
-  'gemini-2.5-flash-lite-preview-09-2025': {
-    thinkingBudget: 0,      // No thinking for lite model
-    temperature: 0.8        // Higher temperature for creativity
-  },
-  'gemini-2.5-flash': {
-    thinkingBudget: -1,     // Dynamic thinking for flash model
-    temperature: 0.5        // Lower temperature for consistency
-  },
-  'gemini-3-flash-preview': {
-    thinkingBudget: -1,     // Dynamic thinking for flash model
-    temperature: 0.5        // Lower temperature for consistency
+  'gemini-3.7-flash': {
+    thinkingBudget: 0,
+    temperature: 0.5
   },
   'gemini-3.1-flash-lite': {
-    thinkingBudget: 0,      // No thinking for lite model
-    temperature: 0.8        // Higher temperature for creativity
+    thinkingBudget: 0,
+    temperature: 0.8
   },
   'gemini-flash-lite-latest': {
-    thinkingBudget: 0,      // No thinking for lite model (latest alias)
-    temperature: 0.8        // Higher temperature for creativity
+    thinkingBudget: 0,
+    temperature: 0.8
   },
-  'gemini-2.5-pro': {
-    thinkingBudget: 1000,   // Fixed thinking budget for pro model
-    temperature: 0.5        // Lower temperature for consistency
-  },
-  'gemini-3-pro-preview': {
-    thinkingBudget: 1000,   // Fixed thinking budget for pro model
-    temperature: 0.5        // Lower temperature for consistency
+  'gemma-3-27b-it': {
+    thinkingBudget: 0,
+    temperature: 0.7
   }
 };
 
@@ -1685,6 +1685,7 @@ module.exports = {
   getDefaultProviderParameters,
   mergeProviderParameters,
   getEffectiveGeminiModel,
+  normalizeGeminiModelName,
   // Gemini key rotation
   selectGeminiApiKey,
   getMaxGeminiApiKeys,


### PR DESCRIPTION
fix(gemini): update default models to Gemini 3.5 Flash to fix 404 on new API keys.

Sorry if this PR is wrong. this is my first PR

.

## Description                                                                                             
                                                                                                               
Google Generative Language API now returns `404 NOT_FOUND` for newly generated API keys (starting with `AQ. `) when requesting legacy or deprecated models such as `gemini-1.5-flash` or `gemini-2.5-flash`.
This causes translations to fail and loop indefinitely with the `TRANSLATION IN PROGRESS` placeholder.

This PR updates the default Gemini models to current supported models (`gemini-3.5-flash` as primary default, with `gemini-3.5-flash-lite` and `gemini-3.7-flash` options), and adds automatic migration/sanitization so existing tokens with legacy model names automatically resolve to `gemini-3.5-flash` without breaking user sessions.                                                                              
                                                                                                               
## Checklist
## Type of Change                                                                                          
                                                                                                               
   - [x] 🐛 Bug fix                                                                                           
   - [ ] ✨ New feature                                                                                       
   - [ ] 📝 Documentation update                                                                              
   - [ ] 🌐 Translation / Localization                                                                        
   - [ ] ♻️ Refactor                                                                                          
   - [x] 🔧 Configuration change                                                                              
                                                                                                               
## Related Issues                                                                                        
Fixes #154                                                  

## Testing
  
 - [x] Tested locally
 - [x] Verified addon installs correctly in Stremio
 - [x] Tested relevant features (subtitles, translation, etc.)
  
## Checklist
  
 - [x] Code follows the existing style
 - [x] Self-reviewed my changes
 - [x] No new warnings or errors in console



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the Gemini model selector with newer model options, including Gemini 3.5 Flash as the default.
  - Added improved handling for configured model names and legacy aliases.

- **Bug Fixes**
  - Prevented invalid or outdated model identifiers from causing configuration issues.
  - Updated model-specific defaults to support current Gemini and Gemma models.

- **Documentation**
  - Refreshed environment configuration examples with the latest Gemini model names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->